### PR TITLE
`setup.py`: Make sure that numpy is available at build time (fixes #2)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,10 @@ setup(
         ],
     },
 
+    setup_requires=[
+        "numpy",
+    ],
+
     install_requires=[
         "Pillow",
         "numpy",


### PR DESCRIPTION
.. since `setup.py` contains `import numpy`

Fixes #2